### PR TITLE
Fixes Retail objective-tracker taint, protected-aura errors, Midnight dungeon tracker behavior, and secret communication strings while preserving Classic compatibility.

### DIFF
--- a/Carbonite.Quests/TrackerHider.lua
+++ b/Carbonite.Quests/TrackerHider.lua
@@ -16,6 +16,8 @@ Nx.Quest = Nx.Quest or {}
 -- WoW globals aliased as locals for hot-path speed.
 local InCombatLockdown = _G.InCombatLockdown or _G.InCombatLockdown
 local UnitName = _G.UnitName or _G.UnitName
+local RegisterStateDriver = _G.RegisterStateDriver
+local UnregisterStateDriver = _G.UnregisterStateDriver
 
 -- BLIZZARD TRACKER HIDING (Retail + Classic + Anniversary + MoP Classic)
 -- Checked = hide; Unchecked = show.
@@ -27,6 +29,18 @@ local NX_TRACKER_FRAMES = {
     "QuestWatchFrame",       -- Fallback (some UI variants)
     "QuestTimerFrame",       -- Anniversary / Classic timed quests
 }
+
+-- ObjectiveTrackerFrame is an Edit Mode-managed Blizzard system on Retail.
+-- Carbonite must not reparent it, alter its alpha/mouse state, or install an
+-- OnShow hook.  Retail visibility is instead controlled through Blizzard's
+-- secure visibility state driver. Legacy tracker frames retain the original
+-- handling on Classic clients.
+local function NxTracker_CanManage(name)
+    if name == "ObjectiveTrackerFrame" and Nx.isRetail then
+        return RegisterStateDriver ~= nil and UnregisterStateDriver ~= nil
+    end
+    return true
+end
 
 local function NxTracker_IsProtectedAndLockedDown(frame)
     return frame and frame.IsProtected and frame:IsProtected() and InCombatLockdown()
@@ -51,6 +65,8 @@ function Nx.Quest:TrackerHider_Init()
         hiddenParent = hiddenParent,
         hooked = {},
         orig = {},
+        retailDriverHidden = false,
+        retailOriginalAlpha = nil,
         pending = false,
     }
 
@@ -69,6 +85,43 @@ function Nx.Quest:TrackerHider_Init()
         self._trackerHider.pending = false
         self:TrackerHider_Apply()
     end)
+end
+
+function Nx.Quest:TrackerHider_SetRetailVisible(frame, visible)
+    local h = self._trackerHider
+    if not h or not frame or not RegisterStateDriver or not UnregisterStateDriver then
+        return
+    end
+
+    if InCombatLockdown() then
+        h.pending = true
+        return
+    end
+
+    if visible then
+        if h.retailOriginalAlpha ~= nil then
+            frame:SetAlpha(h.retailOriginalAlpha)
+            h.retailOriginalAlpha = nil
+        end
+        if h.retailDriverHidden then
+            -- Resolve "show" through Blizzard's secure driver before removing
+            -- Carbonite's driver. This clears statehidden without calling the
+            -- tracker's layout/update methods from addon execution.
+            RegisterStateDriver(frame, "visibility", "show")
+            UnregisterStateDriver(frame, "visibility")
+            h.retailDriverHidden = false
+        end
+    elseif not h.retailDriverHidden then
+        -- The secure state driver evaluates on a short timer. Blizzard can
+        -- call Show() between evaluations while refreshing objectives during
+        -- movement or taxi travel, which otherwise produces a visible flash.
+        -- Alpha is a visual guard only: no script hook or layout method is
+        -- installed, so Blizzard retains its normal update execution path.
+        h.retailOriginalAlpha = frame:GetAlpha()
+        frame:SetAlpha(0)
+        RegisterStateDriver(frame, "visibility", "hide")
+        h.retailDriverHidden = true
+    end
 end
 
 function Nx.Quest:TrackerHider_ShouldHide()
@@ -171,7 +224,11 @@ end
 
 function Nx.Quest:TrackerHider_HookFrame(name)
     local h = self._trackerHider
-    if not h or h.hooked[name] then
+    if not h or h.hooked[name] or not NxTracker_CanManage(name) then
+        return
+    end
+
+    if name == "ObjectiveTrackerFrame" and Nx.isRetail then
         return
     end
 
@@ -201,9 +258,13 @@ function Nx.Quest:TrackerHider_Apply()
     for i = 1, #NX_TRACKER_FRAMES do
         local name = NX_TRACKER_FRAMES[i]
         local frame = _G[name]
-        if frame then
-            self:TrackerHider_HookFrame(name)
-            self:TrackerHider_SetVisible(frame, name, not hide)
+        if frame and NxTracker_CanManage(name) then
+            if name == "ObjectiveTrackerFrame" and Nx.isRetail then
+                self:TrackerHider_SetRetailVisible(frame, not hide)
+            else
+                self:TrackerHider_HookFrame(name)
+                self:TrackerHider_SetVisible(frame, name, not hide)
+            end
         end
     end
 end

--- a/Carbonite/Modules/Comm/ChannelSpamFilter.lua
+++ b/Carbonite/Modules/Comm/ChannelSpamFilter.lua
@@ -41,6 +41,10 @@ end
 local function filter(self_, event, message, sender, _, _, _, _, _, _, channelName)
     if not ChannelSpamFilter.enabled then return false end
     if event == "CHAT_MSG_SYSTEM" then
+        if (_G.Nx and _G.Nx.isRetail) or
+                (_G.canaccessvalue and not _G.canaccessvalue(message)) then
+            return false
+        end
         local com = _G.Nx and _G.Nx.Com
         return com and com.HandleUnavailableWhisper
             and com:HandleUnavailableWhisper(message) or false
@@ -65,6 +69,11 @@ Carbonite.Core.EventBus:Subscribe("CARBONITE_ENABLE", function()
     if ChannelSpamFilter._wired then return end
     ChannelSpamFilter._wired = true
     for _, event in ipairs(CHAT_EVENTS) do
-        _G.ChatFrame_AddMessageEventFilter(event, filter)
+        -- Never attach Carbonite to Retail's potentially secret system-chat
+        -- payload. The Classic clients still use this filter to correlate
+        -- accessible player-not-found messages.
+        if event ~= "CHAT_MSG_SYSTEM" or not (_G.Nx and _G.Nx.isRetail) then
+            _G.ChatFrame_AddMessageEventFilter(event, filter)
+        end
     end
 end)

--- a/Carbonite/Modules/Comm/CommChat.lua
+++ b/Carbonite/Modules/Comm/CommChat.lua
@@ -53,6 +53,16 @@ Carbonite.Core.EventBus:Subscribe("CARBONITE_LOADED", function()
     local original = Com.OnChat_msg_channel
     Com.OnChat_msg_channel = function(self_, event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
         original(self_, event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+
+        -- OnChat_msg_channel also receives CHAT_MSG_SYSTEM.  Those payloads
+        -- are not Carbonite channel traffic and may be secret on Retail 12.1,
+        -- so never forward them through the public channel-message bus.
+        if event ~= "CHAT_MSG_CHANNEL" then return end
+        if _G.canaccessvalue and
+                (not _G.canaccessvalue(arg1) or not _G.canaccessvalue(arg2)) then
+            return
+        end
+
         Carbonite.Core.EventBus:Fire("COMM_CHANNEL_MESSAGE", arg2, arg1, arg9 or arg4)
     end
 end)

--- a/Carbonite/Modules/Comm/CommEngine.lua
+++ b/Carbonite/Modules/Comm/CommEngine.lua
@@ -518,6 +518,15 @@ end
 -- @param message Localized CHAT_MSG_SYSTEM message
 -- @return true when Carbonite caused and handled the error
 function Nx.Com:HandleUnavailableWhisper(message)
+    -- Retail 12.1 can mark CHAT_MSG_SYSTEM payloads secret while chat
+    -- messaging lockdown is active.  Secret strings still report their Lua
+    -- type as "string", but inspecting them with strmatch/gsub/format is
+    -- forbidden from addon code.  Test accessibility before every operation
+    -- that could inspect or convert the payload.
+    if _G.canaccessvalue and not _G.canaccessvalue(message) then
+        return false
+    end
+
     if type(message) ~= "string" or not PLAYER_NOT_FOUND_PATTERN then
         return false
     end

--- a/Carbonite/Modules/InitFlow/EventRegistration.lua
+++ b/Carbonite/Modules/InitFlow/EventRegistration.lua
@@ -45,7 +45,13 @@ function Nx:InitEvents()
     Com:RegisterEvent("CHAT_MSG_CHANNEL_NOTICE", "OnChatEvent")
     Com:RegisterEvent("CHAT_MSG_CHANNEL_LEAVE", "OnChatEvent")
     Com:RegisterEvent("CHAT_MSG_CHANNEL", "OnChat_msg_channel")
-    Com:RegisterEvent("CHAT_MSG_SYSTEM", "OnChat_msg_channel")
+    -- Retail 12.1 can deliver CHAT_MSG_SYSTEM text as a secret string. The
+    -- unavailable-whisper parser is optional social-cache cleanup and must not
+    -- receive that protected payload on Mainline. Classic clients retain the
+    -- legacy accessible system-message path.
+    if not Nx.isRetail then
+        Com:RegisterEvent("CHAT_MSG_SYSTEM", "OnChat_msg_channel")
+    end
 
     -- SOCIAL_QUEUE_UPDATE: Available from Legion+ (group finder social queues)
     if Nx.LegionMaps then


### PR DESCRIPTION
Had very limited time to fully vet this patch.  Needs further validation but with the time I had it gave no errors..  Had a day free so decided to do this and commit for further evaluation..  This is for changes in recent game and secret values.

Retail LUA_WARNING — #564
Prevents Carbonite from reparenting or hooking Retail’s Edit Mode-managed ObjectiveTrackerFrame. Stops Carbonite tracker handling from contaminating Blizzard’s layout execution. Defers protected visibility changes until combat ends. 

Retail GetAuraDataByIndex() — #565
Corrects the upstream tracker taint responsible for Blizzard’s protected-aura warning. Prevents Carbonite execution from reaching Blizzard_MawBuffs:ShouldShowMawBuffs. Leaves Blizzard’s aura and scenario-objective APIs unmodified. 

Midnight dungeons — #566
Restores Hide Blizzards Quest Track Window on Retail through Blizzard’s secure visibility driver. Prevents the objective tracker from flashing during dungeon updates, movement, and flight paths. Restores the tracker for Edit Mode and when the option is disabled. Preserves all Classic tracker behavior.

CommEngine — #567
Rejects inaccessible chat values before string inspection or conversion. Stops secret CHAT_MSG_SYSTEM text from reaching Carbonite on Retail. Restricts the communication bridge to genuine CHAT_MSG_CHANNEL traffic. Retains accessible unavailable-recipient cleanup on Classic clients.